### PR TITLE
refactor(contract): Use address for authentication

### DIFF
--- a/contract/contracts/auditLog.sol
+++ b/contract/contracts/auditLog.sol
@@ -3,10 +3,9 @@ pragma solidity 0.5.x;
 
 contract SK2AddrTable {
     address internal deployerAddr;
-    string ownerSK;
     enum ROLE {NULL, VIEWER, MAINTAINER, OWNER}
-    mapping(string => uint8) public roleMap;
-    event statementLog(string sk, string statement);
+    mapping(address => uint8) public roleMap;
+    event statementLog(address addr, string statement);
 
     modifier ownership {
         assert(deployerAddr == msg.sender);
@@ -14,47 +13,42 @@ contract SK2AddrTable {
     }
 
     // Initailize default state
-    constructor(string memory initOwnerSK) public {
+    constructor(address dbTableOwnerAddr) public {
         // Currently only the deployer can interact with Table Contract
         deployerAddr = msg.sender;
-        ownerSK = initOwnerSK;
-        roleMap[initOwnerSK] = uint8(ROLE.OWNER);
+        roleMap[dbTableOwnerAddr] = uint8(ROLE.OWNER);
     }
 
-    function appendLog(string calldata sk, string calldata statement)
+    function appendLog(address addr, string calldata statement)
         external
         ownership
         returns (bool)
     {
-        // Apppend the statement into the contract with event log (sk, and statement)
-        emit statementLog(sk, statement);
+        // Apppend the statement into the contract with event log (addr, and statement)
+        emit statementLog(addr, statement);
         return true;
     }
 
-    function grantPermission(string calldata sk, uint8 role)
+    function grantPermission(address addr, uint8 role)
         external
         ownership
         returns (bool)
     {
-        roleMap[sk] = role;
+        roleMap[addr] = role;
         return true;
     }
 
-    function verifyPermission(string calldata sk)
+    function verifyPermission(address addr)
         external
         view
         ownership
         returns (uint8)
     {
-        return roleMap[sk];
+        return roleMap[addr];
     }
 
-    function revokePermission(string calldata sk)
-        external
-        ownership
-        returns (bool)
-    {
-        roleMap[sk] = uint8(ROLE.NULL);
+    function revokePermission(address addr) external ownership returns (bool) {
+        roleMap[addr] = uint8(ROLE.NULL);
         return true;
     }
 }

--- a/contract/test/TestAuditLog.sol
+++ b/contract/test/TestAuditLog.sol
@@ -5,8 +5,6 @@ import "truffle/DeployedAddresses.sol";
 import "../contracts/authRole.sol";
 
 contract TestAuditLog {
-    string skOwnerTest = "e0302f799ee2e6bcff366cf395dda8225e0a3ae9250740aeabf8e174a8d55c03";
-    string skMaintainerTest = "aaf4f5s4df5sd47h2ns4i54yk24a65sg7jt7iagj8lo4lj55wfwefjjjukaewqq4";
     string tableNameTest = "TableName";
     address addrTest = 0xc0ffee254729296a45a3885639AC7E10F9d54979;
     enum ROLE {NULL, VIEWER, MAINTAINER, OWNER}
@@ -14,7 +12,7 @@ contract TestAuditLog {
     function testAddNewTableContract() public {
         Authentication auth = new Authentication();
         Assert.equal(
-            auth.addNewTableContract(skOwnerTest, tableNameTest),
+            auth.addNewTableContract(tableNameTest),
             true,
             "Write a Table with a address to the map"
         );
@@ -23,7 +21,7 @@ contract TestAuditLog {
     function testGetAddr() public {
         Authentication auth = new Authentication();
         Assert.equal(
-            auth.addNewTableContract(skOwnerTest, tableNameTest),
+            auth.addNewTableContract(tableNameTest),
             true,
             "Write a Table with a address to the map"
         );
@@ -37,7 +35,7 @@ contract TestAuditLog {
     function testVerifyPermission() public {
         Authentication auth = new Authentication();
         Assert.equal(
-            auth.addNewTableContract(skOwnerTest, tableNameTest),
+            auth.addNewTableContract(tableNameTest),
             true,
             "Write a Table with a address to the map"
         );
@@ -48,8 +46,7 @@ contract TestAuditLog {
         );
         Assert.equal(
             auth.grantPermission(
-                skOwnerTest,
-                skMaintainerTest,
+                addrTest,
                 tableNameTest,
                 uint8(ROLE.MAINTAINER)
             ),
@@ -57,7 +54,7 @@ contract TestAuditLog {
             "Grant user as MAINTAINER"
         );
         Assert.equal(
-            uint256(auth.verifyPermission(skMaintainerTest, tableNameTest)),
+            uint256(auth.verifyPermission(addrTest, tableNameTest)),
             uint256(ROLE.MAINTAINER),
             "Verify user as MAINTAINER"
         );
@@ -66,7 +63,7 @@ contract TestAuditLog {
     function testRevokePermission() public {
         Authentication auth = new Authentication();
         Assert.equal(
-            auth.addNewTableContract(skOwnerTest, tableNameTest),
+            auth.addNewTableContract(tableNameTest),
             true,
             "Write a Table with a address to the map"
         );
@@ -77,8 +74,7 @@ contract TestAuditLog {
         );
         Assert.equal(
             auth.grantPermission(
-                skOwnerTest,
-                skMaintainerTest,
+                addrTest,
                 tableNameTest,
                 uint8(ROLE.MAINTAINER)
             ),
@@ -86,17 +82,17 @@ contract TestAuditLog {
             "Grant user as MAINTAINER"
         );
         Assert.equal(
-            uint256(auth.verifyPermission(skMaintainerTest, tableNameTest)),
+            uint256(auth.verifyPermission(addrTest, tableNameTest)),
             uint256(ROLE.MAINTAINER),
             "Verify user as MAINTAINER"
         );
         Assert.equal(
-            auth.revokePermission(skOwnerTest, skMaintainerTest, tableNameTest),
+            auth.revokePermission(addrTest, tableNameTest),
             true,
             "Revoke user from being MAINTAINER"
         );
         Assert.equal(
-            uint256(auth.verifyPermission(skMaintainerTest, tableNameTest)),
+            uint256(auth.verifyPermission(addrTest, tableNameTest)),
             uint256(ROLE.NULL),
             "Verify the secret key holds by user as NULL"
         );

--- a/contract/test/authRole_test.js
+++ b/contract/test/authRole_test.js
@@ -1,10 +1,6 @@
 const authRole = artifacts.require("Authentication");
 
 contract("authRole", function (accounts) {
-  const skOwnerTest =
-    "e0302f799ee2e6bcff366cf395dda8225e0a3ae9250740aeabf8e174a8d55c03";
-  const skMaintainerTest =
-    "aaf4f5s4df5sd47h2ns4i54yk24a65sg7jt7iagj8lo4lj55wfwefjjjukaewqq4";
   const tableNameTest = "tableName";
   const addrNullTest = 0x0000000000000000000000000000000000000000;
   const dbStatementTest = "UPDATE employee0 SET name='David' WHERE id = 1";
@@ -16,7 +12,6 @@ contract("authRole", function (accounts) {
   it("Write with 'addNewTableContract'", async () => {
     const authRoleInstance = await authRole.deployed();
     const authRoleAddNewTableContract = await authRoleInstance.addNewTableContract.call(
-      skOwnerTest,
       tableNameTest
     );
 
@@ -30,7 +25,6 @@ contract("authRole", function (accounts) {
   it("Retrieve address from mapping", async () => {
     const authRoleInstance = await authRole.deployed();
     const authRoleAddNewTableContract = await authRoleInstance.addNewTableContract.sendTransaction(
-      skOwnerTest,
       tableNameTest
     );
     const authRoleRetrieve = await authRoleInstance.getAddr.call(tableNameTest);
@@ -44,12 +38,10 @@ contract("authRole", function (accounts) {
   it("Append audit log to Table Contract", async () => {
     const authRoleInstance = await authRole.deployed();
     const authRoleAddNewTableContract = await authRoleInstance.addNewTableContract.sendTransaction(
-      skOwnerTest,
       tableNameTest
     );
 
     const authRoleAppend = await authRoleInstance.appendLog.call(
-      skOwnerTest,
       tableNameTest,
       dbStatementTest,
       ownerRole
@@ -61,96 +53,92 @@ contract("authRole", function (accounts) {
     );
   });
 
-  it("Make a user as MAINTAINER", async () => {
+  it("Grant the given address (`accounts[1]`) as MAINTAINER", async () => {
     const authRoleInstance = await authRole.deployed();
     const authRoleAddNewTableContract = await authRoleInstance.addNewTableContract.sendTransaction(
-      skOwnerTest,
       tableNameTest
     );
 
     const authGrantPermission = await authRoleInstance.grantPermission.call(
-      skOwnerTest,
-      skMaintainerTest,
+      accounts[1],
       tableNameTest,
       maintainerRole
     );
-    assert.equal(authGrantPermission, true, "Assign skTest as MAINTAINER");
+    assert.equal(
+      authGrantPermission,
+      true,
+      "Assign the given address as a MAINTAINER"
+    );
   });
 
-  it("Check whether skTest is a MAINTAINER", async () => {
+  it("Check whether the given address is a MAINTAINER or not", async () => {
     const authRoleInstance = await authRole.deployed();
     const authRoleAddNewTableContract = await authRoleInstance.addNewTableContract.sendTransaction(
-      skOwnerTest,
       tableNameTest
     );
 
     const authGrantPermission = await authRoleInstance.grantPermission.sendTransaction(
-      skOwnerTest,
-      skMaintainerTest,
+      accounts[1],
       tableNameTest,
       maintainerRole
     );
     const authVerifyPermission = await authRoleInstance.verifyPermission.call(
-      skMaintainerTest,
+      accounts[1],
       tableNameTest
     );
     assert.equal(
       authVerifyPermission,
       maintainerRole,
-      "skTest doesn't refer to a MAINTAINER role"
+      "The given address doesn't refer to a MAINTAINER role"
     );
   });
 
-  it("Revoke skTest from being a MAINTAINER", async () => {
+  it("Revoke the given address from being a MAINTAINER", async () => {
     const authRoleInstance = await authRole.deployed();
     const authRoleAddNewTableContract = await authRoleInstance.addNewTableContract.sendTransaction(
-      skOwnerTest,
       tableNameTest
     );
 
     const authGrantPermission = await authRoleInstance.grantPermission.sendTransaction(
-      skOwnerTest,
-      skMaintainerTest,
+      accounts[1],
       tableNameTest,
       maintainerRole
     );
     var authVerifyPermission = await authRoleInstance.verifyPermission.call(
-      skMaintainerTest,
+      accounts[1],
       tableNameTest
     );
     assert.equal(
       authVerifyPermission,
       maintainerRole,
-      "skTest doesn't refer to a MAINTAINER role"
+      "The given address doesn't refer to a MAINTAINER role"
     );
 
     // Check the response
     var authRevokePermission = await authRoleInstance.revokePermission.call(
-      skOwnerTest,
-      skMaintainerTest,
+      accounts[1],
       tableNameTest
     );
     assert.equal(
       authRevokePermission,
       true,
-      "Failed to revoke the role of skTest from being a MAINTAINER"
+      "Failed to revoke the role of the given address from being a MAINTAINER"
     );
 
     // Revoke again for modifying the data on Blockchain
     authRevokePermission = await authRoleInstance.revokePermission.sendTransaction(
-      skOwnerTest,
-      skMaintainerTest,
+      accounts[1],
       tableNameTest
     );
     authVerifyPermission = await authRoleInstance.verifyPermission.call(
-      skMaintainerTest,
+      accounts[1],
       tableNameTest
     );
 
     assert.equal(
       authVerifyPermission,
       nullRole,
-      "Failed to revoke the role of skTest from being a MAINTAINER"
+      "Failed to revoke the role of the given address from being a MAINTAINER"
     );
   });
 });


### PR DESCRIPTION
Use Ethereum address for authentication during the interaction with
the contract can solve the dramatic vulnerability caused by calling
contract functions with secret key. And it somehow reduce the number
of function parameters, too.